### PR TITLE
update blacklist atomically with `ipset swap`

### DIFF
--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -24,15 +24,18 @@ sort $IP_BLACKLIST_TMP -n | uniq > $IP_BLACKLIST
 rm $IP_BLACKLIST_TMP
 wc -l $IP_BLACKLIST
 
-ipset flush blacklist
+ipset create blacklist_tmp hash:net
 egrep -v "^#|^$" $IP_BLACKLIST | while IFS= read -r ip
 do
-        ipset add blacklist $ip
+        ipset add blacklist_tmp $ip
 done
 
 if [ -f $IP_BLACKLIST_CUSTOM ]; then
         egrep -v "^#|^$" $IP_BLACKLIST_CUSTOM | while IFS= read -r ip
         do
-                ipset add blacklist $ip
+                ipset add blacklist_tmp $ip
         done
 fi
+
+ipset swap blacklist blacklist_tmp
+ipset destroy blacklist_tmp


### PR DESCRIPTION
Thanks for the script, I'm using it on my OpenWRT router. I made this patch to create a temporary ipset with the updated IP list and swap with the actual blacklist so the blacklist is never empty (instead of flushing the blacklist and then generating the new one). It takes almost a minute to create the new blacklist on my router, and this avoids a small amount of downtime.
