### PR TITLE
Add -e flag of bash

### DIFF
--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 IP_TMP=/tmp/ip.tmp
 IP_BLACKLIST=/etc/ip-blacklist.conf
 IP_BLACKLIST_TMP=/tmp/ip-blacklist.tmp


### PR DESCRIPTION
If curl or ipset is not in the path, the script should stop. Other errors (e.g. a URL change) should be caught by the script if recoverable.
