### PR TITLE
Bail out in case of error

### DIFF
--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 IP_TMP=/tmp/ip.tmp
 IP_BLACKLIST=/etc/ip-blacklist.conf
 IP_BLACKLIST_TMP=/tmp/ip-blacklist.tmp


### PR DESCRIPTION
set -e immediately ends the execution of the shell upon an error that is not caught by || or by having it in an if control statement. This comes handy for smallish servers that might not have curl but wget installed.
