### PR TITLE
100 x performance increase and added installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A tiny Bash shell script which uses ipset and iptables to ban a large number of 
 The ipset command doesn't work under OpenVZ. It works fine on dedicated and fully virtualized servers like KVM though.
 
 ## Quick start for Debian/Ubuntu based installations
+Do
+curl -sSL https://raw.githubusercontent.com/bryanroscoe/ipset-blacklist/master/installUbuntu14_04.sh | bash
+
+or
+
 1. Copy update-blacklist.sh into /usr/local/bin
 2. chmod +x /usr/local/bin/update-blacklist.sh
 2. Modify update-blacklist.sh according to your needs. Per default, the blacklisted IP addresses will be saved to /etc/ip-blacklist.conf

--- a/blocklistInit
+++ b/blocklistInit
@@ -1,0 +1,5 @@
+#!/bin/sh
+ipset restore < /etc/ip-blacklist.conf
+iptables-restore < /etc/iptables.rules
+
+exit 0

--- a/installUbuntu14_04.sh
+++ b/installUbuntu14_04.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+\curl -sSL https://raw.githubusercontent.com/bryanroscoe/ipset-blacklist/master/update-blacklist.sh > /etc/cron.daily/update-blacklist.sh
+chmod +x /etc/cron.daily/update-blacklist.sh
+\curl -sSL https://raw.githubusercontent.com/bryanroscoe/ipset-blacklist/master/blacklistInit >  /etc/network/if-pre-up.d/blocklistInit
+chmod +x /etc/network/if-pre-up.d/blocklistInit
+apt-get install -y ipset
+ipset create blacklist hash:net
+/etc/cron.daily/update-blacklist.sh
+iptables -I INPUT -m set --match-set blacklist src -j DROP
+iptables-save | tee /etc/iptables.rules

--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-IP_BLACKLIST_RESTORE=$(mktemp)
-IP_BLACKLIST=/etc/ip-blacklist.conf
+IP_BLACKLIST_RESTORE=/etc/ip-blacklist.conf
+IP_BLACKLIST=/etc/ip-blacklist.list
 IP_BLACKLIST_TMP=$(mktemp)
 IP_BLACKLIST_CUSTOM=/etc/ip-blacklist-custom.conf # optional
 BLACKLISTS=(
@@ -31,6 +31,7 @@ wc -l $IP_BLACKLIST
 
 ipset destroy blacklist_tmp
 echo "create blacklist_tmp hash:net family inet hashsize 65536 maxelem 65536" > $IP_BLACKLIST_RESTORE
+echo "create blacklist hash:net -exist family inet hashsize 65536 maxelem 65536" >> $IP_BLACKLIST_RESTORE
 
 egrep -v "^#|^$" $IP_BLACKLIST | while IFS= read -r ip
 do
@@ -43,6 +44,6 @@ if [ -f $IP_BLACKLIST_CUSTOM ]; then
                 echo "add blacklist_tmp $ip" >> $IP_BLACKLIST_RESTORE
         done
 fi
+echo "swap blacklist blacklist_tmp" >> $IP_BLACKLIST_RESTORE
+echo "destroy blacklist_tmp" >> $IP_BLACKLIST_RESTORE
 ipset restore < $IP_BLACKLIST_RESTORE
-ipset swap blacklist blacklist_tmp
-ipset destroy blacklist_tmp

--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+IP_BLACKLIST_RESTORE=$(mktemp)
 IP_BLACKLIST=/etc/ip-blacklist.conf
 IP_BLACKLIST_TMP=$(mktemp)
 IP_BLACKLIST_CUSTOM=/etc/ip-blacklist-custom.conf # optional
 BLACKLISTS=(
 "http://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1" # Project Honey Pot Directory of Dictionary Attacker IPs
 "http://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1"  # TOR Exit Nodes
-"https://www.maxmind.com/en/anonymous-proxy-fraudulent-ip-address-list" # MaxMind GeoIP Anonymous Proxies
 "http://danger.rulez.sk/projects/bruteforceblocker/blist.php" # BruteForceBlocker IP List
 "http://www.spamhaus.org/drop/drop.lasso" # Spamhaus Don't Route Or Peer List (DROP)
 "http://cinsscore.com/list/ci-badguys.txt" # C.I. Army Malicious IP List
@@ -29,18 +29,20 @@ sort $IP_BLACKLIST_TMP -n | uniq > $IP_BLACKLIST
 rm $IP_BLACKLIST_TMP
 wc -l $IP_BLACKLIST
 
-ipset create blacklist_tmp hash:net
+ipset destroy blacklist_tmp
+echo "create blacklist_tmp hash:net family inet hashsize 65536 maxelem 65536" > $IP_BLACKLIST_RESTORE
+
 egrep -v "^#|^$" $IP_BLACKLIST | while IFS= read -r ip
 do
-        ipset add blacklist_tmp $ip
+    echo "add blacklist_tmp $ip" >> $IP_BLACKLIST_RESTORE
 done
 
 if [ -f $IP_BLACKLIST_CUSTOM ]; then
         egrep -v "^#|^$" $IP_BLACKLIST_CUSTOM | while IFS= read -r ip
         do
-                ipset add blacklist_tmp $ip
+                echo "add blacklist_tmp $ip" >> $IP_BLACKLIST_RESTORE
         done
 fi
-
+ipset restore < $IP_BLACKLIST_RESTORE
 ipset swap blacklist blacklist_tmp
 ipset destroy blacklist_tmp


### PR DESCRIPTION
We changed the script to use ipset restore to batch to adds. This speeds up the script to be much faster. Also had to remove the maxmind because it was causing a long hang in the script and isn't that malicious. Can be added back if needed.

Added an install script for ubuntu 14.04 that installs the script and sets up to update every day and reapply rules at reboot.