### PR TITLE
various fixes/rewrite

### DIFF
--- a/ipset-blacklist.conf
+++ b/ipset-blacklist.conf
@@ -2,22 +2,22 @@ IPSET_BLACKLIST_NAME=blacklist # change it if it collides with a pre-existing ip
 IPSET_TMP_BLACKLIST_NAME=${IPSET_BLACKLIST_NAME}-tmp
 IP_BLACKLIST_RESTORE=${IP_BLACKLIST_DIR}/ip-blacklist.restore
 IP_BLACKLIST=${IP_BLACKLIST_DIR}/ip-blacklist.list
-IP_BLACKLIST_CUSTOM=${IP_BLACKLIST_DIR}/ip-blacklist-custom.list # optional, for your personal nemeses (no typo, plural)
-HASHSIZE=65536 # the initial hash size for the set. Don't touch unless you know what you're doing.
-MAXELEM=65536 # the maximal number of elements which can be stored in the set
+VERBOSE=no # probably set to "no" for cron jobs
+FORCE=yes # will create the ipset-iptable binding if it does not already exist
 
 # List of URLs for IP blacklists. Currently, only IPv4 is supported in this script, everything else will be filtered.
 BLACKLISTS=(
-"http://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1" # Project Honey Pot Directory of Dictionary Attacker IPs
-"http://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1"  # TOR Exit Nodes
-"https://www.maxmind.com/en/proxy-detection-sample-list" # MaxMind GeoIP Anonymous Proxies
-"http://danger.rulez.sk/projects/bruteforceblocker/blist.php" # BruteForceBlocker IP List
-"http://www.spamhaus.org/drop/drop.lasso" # Spamhaus Don't Route Or Peer List (DROP)
-"http://cinsscore.com/list/ci-badguys.txt" # C.I. Army Malicious IP List
-"http://www.openbl.org/lists/base.txt"  # OpenBL.org 30 day List
-"http://www.autoshun.org/files/shunlist.csv" # Autoshun Shun List
-"http://lists.blocklist.de/lists/all.txt" # blocklist.de attackers
-"http://www.stopforumspam.com/downloads/toxic_ip_cidr.txt" # StopForumSpam
-"http://blocklist.greensnow.co/greensnow.txt" # GreenSnow
-# "http://ipverse.net/ipblocks/data/countries/xx.zone" # Ban an entire country, see http://ipverse.net/ipblocks/data/countries/
+    # "file:///etc/ipset-blacklist/ip-blacklist-custom.list" # optional, for your personal nemeses (no typo, plural)
+    "http://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1" # Project Honey Pot Directory of Dictionary Attacker IPs
+    "http://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1"  # TOR Exit Nodes
+    "https://www.maxmind.com/en/proxy-detection-sample-list" # MaxMind GeoIP Anonymous Proxies
+    "http://danger.rulez.sk/projects/bruteforceblocker/blist.php" # BruteForceBlocker IP List
+    "http://www.spamhaus.org/drop/drop.lasso" # Spamhaus Don't Route Or Peer List (DROP)
+    "http://cinsscore.com/list/ci-badguys.txt" # C.I. Army Malicious IP List
+    "http://www.openbl.org/lists/base.txt"  # OpenBL.org 30 day List
+    "http://www.autoshun.org/files/shunlist.csv" # Autoshun Shun List
+    "http://lists.blocklist.de/lists/all.txt" # blocklist.de attackers
+    "http://www.stopforumspam.com/downloads/toxic_ip_cidr.txt" # StopForumSpam
+    "http://blocklist.greensnow.co/greensnow.txt" # GreenSnow
+    # "http://ipverse.net/ipblocks/data/countries/xx.zone" # Ban an entire country, see http://ipverse.net/ipblocks/data/countries/
 )


### PR DESCRIPTION
- added the couple FORCE/VERBOSE parameters, so that the script can be used
  in a cron and/or a fresh installation without any manual work nor noise inside logs

- shellscripting: quote variables, especially those which may contain spaces
- shellscripting: prefix possibly aliased commands with `command`
- shellscripting: use -f to rm (possibly aliased to rm -i)
- shellscripting: use cat + EOF to write lines to files
- standard: use ipset -file rather than piping

- redirect error output to ... stderr
- be nice: use a specific user agent, so that blacklist author have the
  possibility to manage this (flood, stats, bandwith increase, ...)
  It's always possible to hide the UA later if it's really needed

- simplify the script: custom blacklist can now be set directly inside the
  BLACKLISTS bash array rather than being a specific case (fix issue #21)
  (comes at the price of not having stats for the custom file, but who cares?)
- simplify the script: test command existence just once
- simplify the script: one shot IP list filtering using a couple of sort/sed pipes
- simplify the script: one shot ipset with just one sed expr