### PR TITLE
Added ipset-persistent compatibility

### DIFF
--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -18,6 +18,10 @@ if ! which curl egrep grep ipset iptables sed sort wc &> /dev/null; then
     exit 1
 fi
 
+if [ -f  /usr/share/netfilter-persistent/plugins.d/*ipset ]; then
+	IP_BLACKLIST_RESTORE=/etc/iptables/rules.ipset
+fi
+
 if [[ ! -d $(dirname "$IP_BLACKLIST") || ! -d $(dirname "$IP_BLACKLIST_RESTORE") ]]; then
     echo >&2 "Error: missing directory(s): $(dirname "$IP_BLACKLIST" "$IP_BLACKLIST_RESTORE"|sort -u)"
     exit 1


### PR DESCRIPTION
With ipset-persistent, part of netfilter-persistent, the ipset is loaded earlier in the startup proces. 
The script in /etc/network/if-up.d can be removed.