### PR TITLE
Remove MaxMind

### DIFF
--- a/ipset-blacklist.conf
+++ b/ipset-blacklist.conf
@@ -14,7 +14,6 @@ BLACKLISTS=(
     # "file:///etc/ipset-blacklist/ip-blacklist-custom.list" # optional, for your personal nemeses (no typo, plural)
     "https://www.projecthoneypot.org/list_of_ips.php?t=d&rss=1" # Project Honey Pot Directory of Dictionary Attacker IPs
     "https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1"  # TOR Exit Nodes
-    "https://www.maxmind.com/en/high-risk-ip-sample-list" # MaxMind GeoIP Anonymous Proxies
     "http://danger.rulez.sk/projects/bruteforceblocker/blist.php" # BruteForceBlocker IP List
     "https://www.spamhaus.org/drop/drop.lasso" # Spamhaus Don't Route Or Peer List (DROP)
     "https://cinsscore.com/list/ci-badguys.txt" # C.I. Army Malicious IP List


### PR DESCRIPTION
MaxMind returns a 403, probably because it is no longer free. So we can do away with it.