### PR TITLE
Fix download link for ipset-blacklist.conf and update-blacklist.sh

### DIFF
--- a/archive/README.md
+++ b/archive/README.md
@@ -20,7 +20,7 @@ The ipset command doesn't work under OpenVZ. It works fine on dedicated and full
 
 1. `wget -O /usr/local/sbin/update-blacklist.sh https://raw.githubusercontent.com/trick77/ipset-blacklist/master/update-blacklist.sh`
 2. `chmod +x /usr/local/sbin/update-blacklist.sh`
-3. `mkdir -p /etc/ipset-blacklist ; wget -O /etc/ipset-blacklist/ipset-blacklist.conf https://raw.githubusercontent.com/trick77/ipset-blacklist/master/ipset-blacklist.conf`
+3. `mkdir -p /etc/ipset-blacklist ; wget -O /etc/ipset-blacklist/ipset-blacklist.conf (https://raw.githubusercontent.com/trick77/nftables-blacklist/refs/heads/master/archive/ipset-blacklist.conf`
 4. Modify `ipset-blacklist.conf` according to your needs. Per default, the blacklisted IP addresses will be saved to `/etc/ipset-blacklist/ip-blacklist.restore`
 5. `apt-get install ipset`
 6. Create the ipset blacklist and insert it into your iptables input filter (see below). After proper testing, make sure to persist it in your firewall script or similar or the rules will be lost after the next reboot.


### PR DESCRIPTION
Updated the URL for downloading ipset-blacklist.conf and update-blacklist.sh to point to the archive repository location.