### PR TITLE
Add WHITELIST_JSON_SOURCES for jq-extracted whitelist entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Blacklist update complete
 - [Configuration Options](#configuration-options)
 - [Customizing Blacklists](#customizing-blacklists)
 - [Whitelist (Prevent Self-Blocking)](#whitelist-prevent-self-blocking)
+  - [Manual Whitelist](#manual-whitelist)
+  - [JSON Whitelist Sources (jq)](#json-whitelist-sources-jq)
+  - [Auto-Detect Server IPs](#auto-detect-server-ips)
 - [Dry Run Mode](#dry-run-mode)
 - [Cron Mode](#cron-mode)
 - [Troubleshooting](#troubleshooting)
@@ -65,6 +68,7 @@ Blacklist update complete
 - nftables
 - iprange - combines overlapping IP ranges and handles whitelist subtraction
 - curl, grep, sed, sort, wc (usually pre-installed)
+- jq - **optional**, only required if you use `WHITELIST_JSON_SOURCES` to extract whitelist IPs from JSON endpoints
 
 ## Quick Start (Debian/Ubuntu)
 
@@ -255,6 +259,25 @@ WHITELIST=(
 For IPv4, whitelisting a range like `10.0.0.0/8` will correctly exclude all IPs in that range, even if the blacklist contains individual IPs like `10.1.2.3`.
 
 **Note:** IPv6 whitelist only matches exact addresses (CIDR ranges not supported for IPv6 whitelist).
+
+### JSON Whitelist Sources (jq)
+
+If a provider publishes their IP ranges as JSON (e.g. cloud providers, VPN services), you can pull the IPs directly into the whitelist using `jq` filters. Each entry in `WHITELIST_JSON_SOURCES` has the form `URL|JQ_FILTER` (split on the first `|` so filter operators like `//` and `|` are preserved).
+
+```bash
+WHITELIST_JSON_SOURCES=(
+    # Mullvad WireGuard relay IPv4 addresses (remote URL)
+    "https://api.mullvad.net/app/v1/relays|.wireguard.relays[].ipv4_addr_in"
+
+    # Local JSON file (alternative to a plain text list)
+    # e.g. [ "203.0.113.10", "198.51.100.0/24", "2001:db8::1" ]
+    "file:///etc/nftables-blacklist/my-whitelist.json|.[]"
+)
+```
+
+The filter must emit one IP or CIDR per line on stdout. IPv4 vs IPv6 routing is automatic (entries containing `:` go to the IPv6 whitelist).
+
+`jq` is only required when this array has entries. Install with `apt install jq`. If `WHITELIST_JSON_SOURCES` is empty (the default), the script runs without `jq` installed.
 
 ### Auto-Detect Server IPs
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ The filter must emit one IP or CIDR per line on stdout. IPv4 vs IPv6 routing is 
 
 `jq` is only required when this array has entries. Install with `apt install jq`. If `WHITELIST_JSON_SOURCES` is empty (the default), the script runs without `jq` installed.
 
+**Fail-fast behavior:** if a JSON whitelist source fails (download error, malformed jq filter, missing `jq`), the script aborts before applying any rules. Silently skipping a configured whitelist source would let provider IPs you intended to protect end up blacklisted — exactly the failure mode this feature exists to prevent. A filter that produces zero IPs is logged as a warning but does not abort.
+
 ### Auto-Detect Server IPs
 
 To automatically whitelist your server's own IPs (recommended):

--- a/nftables-blacklist.conf
+++ b/nftables-blacklist.conf
@@ -71,6 +71,18 @@ WHITELIST=(
   # "2001:db8::1"        # IPv6
 )
 
+# JSON whitelist sources extracted via jq.
+# Each entry: "URL|JQ_FILTER" (split on the first '|').
+# The filter must emit one IP/CIDR per line on stdout.
+# Requires `jq` installed - only when this array has entries.
+WHITELIST_JSON_SOURCES=(
+  # Mullvad WireGuard relay IPv4 addresses (remote URL)
+  # "https://api.mullvad.net/app/v1/relays|.wireguard.relays[].ipv4_addr_in"
+
+  # Local JSON file (e.g. [ "203.0.113.10", "198.51.100.0/24", "2001:db8::1" ])
+  # "file:///etc/nftables-blacklist/my-whitelist.json|.[]"
+)
+
 #=== OPTIONAL OVERRIDES ===#
 # Uncomment to change defaults:
 

--- a/test/fixtures/whitelist-gcloud.json
+++ b/test/fixtures/whitelist-gcloud.json
@@ -1,0 +1,26 @@
+{
+  "syncToken": "1700000000000",
+  "creationTime": "2026-01-01T00:00:00",
+  "prefixes": [
+    {
+      "ipv4Prefix": "34.0.0.0/15",
+      "service": "Google Cloud",
+      "scope": "us-central1"
+    },
+    {
+      "ipv6Prefix": "2600:1900::/32",
+      "service": "Google Cloud",
+      "scope": "us-central1"
+    },
+    {
+      "ipv4Prefix": "35.190.0.0/17",
+      "service": "Google Cloud",
+      "scope": "us-east1"
+    },
+    {
+      "ipv6Prefix": "2607:f8b0::/32",
+      "service": "Google Cloud",
+      "scope": "us-east1"
+    }
+  ]
+}

--- a/test/fixtures/whitelist-mullvad.json
+++ b/test/fixtures/whitelist-mullvad.json
@@ -1,0 +1,24 @@
+{
+  "wireguard": {
+    "relays": [
+      {
+        "hostname": "test-wg-001",
+        "ipv4_addr_in": "185.213.154.66",
+        "ipv6_addr_in": "2a03:1b20:1:f011::a01f"
+      },
+      {
+        "hostname": "test-wg-002",
+        "ipv4_addr_in": "185.213.154.67",
+        "ipv6_addr_in": "2a03:1b20:1:f011::a020"
+      },
+      {
+        "hostname": "test-wg-003",
+        "ipv4_addr_in": "193.32.127.66",
+        "ipv6_addr_in": "2a03:1b20:5:f011::a02a"
+      }
+    ]
+  },
+  "openvpn": {
+    "relays": []
+  }
+}

--- a/test/fixtures/whitelist-test-blacklist.txt
+++ b/test/fixtures/whitelist-test-blacklist.txt
@@ -1,0 +1,16 @@
+# Synthetic blacklist for whitelist matrix tests
+# Contains:
+#   - one Mullvad IP (185.213.154.66) - whitelisted via JSON
+#   - one GCP IPv4 inside 34.0.0.0/15 (34.0.5.5) - whitelisted via JSON CIDR
+#   - one literal whitelist IP (203.0.113.99) - whitelisted via WHITELIST array
+#   - one normal IP (1.2.3.4) - must survive
+#   - one literal IPv6 whitelist target (2001:db8:dead::1) - whitelisted via WHITELIST array
+#   - one normal IPv6 (2001:4860:4860::8888) - must survive
+#   - GCP IPv6 CIDR exact entry (2600:1900::/32) - whitelisted via JSON exact match
+185.213.154.66
+34.0.5.5
+203.0.113.99
+1.2.3.4
+2001:db8:dead::1
+2001:4860:4860::8888
+2600:1900::/32

--- a/test/integration/whitelist_modes.bats
+++ b/test/integration/whitelist_modes.bats
@@ -1,0 +1,216 @@
+#!/usr/bin/env bats
+#
+# Integration matrix for whitelist modes:
+#   - WHITELIST literals: empty | populated
+#   - WHITELIST_JSON_SOURCES:     empty | populated
+#   - jq:                 installed | not installed
+#
+# Each row runs in --dry-run mode and asserts whitelisted IPs are filtered
+# out of the produced lists, while non-whitelisted IPs survive.
+#
+
+load '../helpers/test_helper'
+
+setup() {
+  command -v iprange >/dev/null || skip "iprange not installed"
+
+  export TEST_OUTPUT_DIR="${BATS_TMPDIR}/nftables-blacklist"
+  mkdir -p "${TEST_OUTPUT_DIR}"
+  chmod 777 "${TEST_OUTPUT_DIR}"
+
+  export TEST_BLACKLIST="file://${FIXTURES_DIR}/whitelist-test-blacklist.txt"
+  export MULLVAD_URL="file://${FIXTURES_DIR}/whitelist-mullvad.json"
+
+  export V4_LIST="${TEST_OUTPUT_DIR}/ip-blacklist.list.v4"
+  export V6_LIST="${TEST_OUTPUT_DIR}/ip-blacklist.list.v6"
+}
+
+teardown() {
+  rm -rf "${BATS_TMPDIR}/nftables-blacklist"
+  rm -f "${BATS_TMPDIR}"/test-config-*.conf
+  rm -rf "${BATS_TMPDIR}/no-jq-bin"
+}
+
+# Build a hermetic PATH containing every binary the script needs EXCEPT jq.
+# Returns the path to the sandbox bin dir on stdout.
+build_path_without_jq() {
+  local sandbox="${BATS_TMPDIR}/no-jq-bin"
+  rm -rf "$sandbox"
+  mkdir -p "$sandbox"
+  local cmd p
+  for cmd in bash sh curl grep sed sort wc iprange awk tr cut cat dirname basename mktemp rm cp mv chmod chown date head tail tee uname env hostname ip nft true false test ls stat readlink find xargs; do
+    p=$(command -v "$cmd" 2>/dev/null) || continue
+    ln -sf "$p" "$sandbox/$cmd"
+  done
+  echo "$sandbox"
+}
+
+# Write a config file. Args: path, WHITELIST_array_literal, WHITELIST_JSON_SOURCES_array_literal
+write_config() {
+  local path="$1" wl="$2" wlj="$3"
+  cat > "$path" <<EOF
+BLACKLISTS=(
+  "${TEST_BLACKLIST}"
+)
+
+NFT_BLACKLIST_SCRIPT="${TEST_OUTPUT_DIR}/blacklist.nft"
+IP_BLACKLIST="${TEST_OUTPUT_DIR}/ip-blacklist.list"
+
+NFT_TABLE_NAME="test_blacklist"
+NFT_SET_NAME_V4="test_blacklist4"
+NFT_SET_NAME_V6="test_blacklist6"
+NFT_CHAIN_NAME="test_input"
+NFT_CHAIN_PRIORITY=-200
+
+ENABLE_IPV4=yes
+ENABLE_IPV6=yes
+AUTO_WHITELIST=no
+CHUNK_SIZE=100
+
+WHITELIST=( ${wl} )
+WHITELIST_JSON_SOURCES=( ${wlj} )
+EOF
+}
+
+#=============================================================================
+# Row 1: WHITELIST empty, WHITELIST_JSON_SOURCES empty, jq installed
+#=============================================================================
+@test "matrix-1: no whitelists, jq present -> all blacklist IPs survive" {
+  command -v jq >/dev/null || skip "jq not installed"
+  local cfg="${BATS_TMPDIR}/test-config-1.conf"
+  write_config "$cfg" "" ""
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  grep -q "^1\.2\.3\.4$" "$V4_LIST"
+  grep -q "^185\.213\.154\.66$" "$V4_LIST"
+  grep -q "2001:4860:4860::8888" "$V6_LIST"
+}
+
+#=============================================================================
+# Row 2: WHITELIST empty, WHITELIST_JSON_SOURCES empty, jq NOT installed
+#=============================================================================
+@test "matrix-2: no whitelists, jq absent -> runs, no jq required" {
+  local cfg="${BATS_TMPDIR}/test-config-2.conf"
+  write_config "$cfg" "" ""
+
+  local sandbox
+  sandbox=$(build_path_without_jq)
+
+  PATH="$sandbox" run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  grep -q "^1\.2\.3\.4$" "$V4_LIST"
+}
+
+#=============================================================================
+# Row 3: WHITELIST populated, WHITELIST_JSON_SOURCES empty, jq installed
+#=============================================================================
+@test "matrix-3: literal whitelist only, jq present -> literal entries filtered" {
+  command -v jq >/dev/null || skip "jq not installed"
+  local cfg="${BATS_TMPDIR}/test-config-3.conf"
+  write_config "$cfg" '"203.0.113.99" "2001:db8:dead::1"' ""
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^203\.0\.113\.99$" "$V4_LIST"
+  ! grep -q "^2001:db8:dead::1$" "$V6_LIST"
+  # Non-whitelisted IPs must remain
+  grep -q "^1\.2\.3\.4$" "$V4_LIST"
+  grep -q "^185\.213\.154\.66$" "$V4_LIST"
+}
+
+#=============================================================================
+# Row 4: WHITELIST populated, WHITELIST_JSON_SOURCES empty, jq NOT installed
+#=============================================================================
+@test "matrix-4: literal whitelist only, jq absent -> literal whitelist still works" {
+  local cfg="${BATS_TMPDIR}/test-config-4.conf"
+  write_config "$cfg" '"203.0.113.99" "2001:db8:dead::1"' ""
+
+  local sandbox
+  sandbox=$(build_path_without_jq)
+
+  PATH="$sandbox" run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^203\.0\.113\.99$" "$V4_LIST"
+  ! grep -q "^2001:db8:dead::1$" "$V6_LIST"
+  grep -q "^1\.2\.3\.4$" "$V4_LIST"
+}
+
+#=============================================================================
+# Row 5: WHITELIST empty, WHITELIST_JSON_SOURCES populated, jq installed
+#=============================================================================
+@test "matrix-5: JSON whitelist only, jq present -> JSON entries filtered" {
+  command -v jq >/dev/null || skip "jq not installed"
+  local cfg="${BATS_TMPDIR}/test-config-5.conf"
+  write_config "$cfg" "" '"'"${MULLVAD_URL}"'|.wireguard.relays[].ipv4_addr_in"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^185\.213\.154\.66$" "$V4_LIST"
+  grep -q "^1\.2\.3\.4$" "$V4_LIST"
+}
+
+#=============================================================================
+# Row 6: WHITELIST empty, WHITELIST_JSON_SOURCES populated, jq NOT installed
+#=============================================================================
+@test "matrix-6: JSON whitelist set but jq absent -> dies before download" {
+  local cfg="${BATS_TMPDIR}/test-config-6.conf"
+  write_config "$cfg" "" '"'"${MULLVAD_URL}"'|.wireguard.relays[].ipv4_addr_in"'
+
+  local sandbox
+  sandbox=$(build_path_without_jq)
+
+  PATH="$sandbox" run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Required command not found: jq"* ]]
+  # No output files should have been written
+  [ ! -f "$V4_LIST" ]
+  [ ! -f "$V6_LIST" ]
+}
+
+#=============================================================================
+# Row 7: WHITELIST populated, WHITELIST_JSON_SOURCES populated, jq installed
+#=============================================================================
+@test "matrix-7: both whitelists, jq present -> both sets of IPs filtered" {
+  command -v jq >/dev/null || skip "jq not installed"
+  local cfg="${BATS_TMPDIR}/test-config-7.conf"
+  write_config "$cfg" \
+    '"203.0.113.99" "2001:db8:dead::1"' \
+    '"'"${MULLVAD_URL}"'|.wireguard.relays[].ipv4_addr_in"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  # Literal whitelist
+  ! grep -q "^203\.0\.113\.99$" "$V4_LIST"
+  ! grep -q "^2001:db8:dead::1$" "$V6_LIST"
+  # JSON whitelist
+  ! grep -q "^185\.213\.154\.66$" "$V4_LIST"
+  # Non-whitelisted survives
+  grep -q "^1\.2\.3\.4$" "$V4_LIST"
+  grep -q "2001:4860:4860::8888" "$V6_LIST"
+}
+
+#=============================================================================
+# Row 8: WHITELIST populated, WHITELIST_JSON_SOURCES populated, jq NOT installed
+#=============================================================================
+@test "matrix-8: both whitelists set but jq absent -> dies, ignores literals too" {
+  local cfg="${BATS_TMPDIR}/test-config-8.conf"
+  write_config "$cfg" \
+    '"203.0.113.99"' \
+    '"'"${MULLVAD_URL}"'|.wireguard.relays[].ipv4_addr_in"'
+
+  local sandbox
+  sandbox=$(build_path_without_jq)
+
+  PATH="$sandbox" run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Required command not found: jq"* ]]
+}

--- a/test/unit/fetch_json_whitelist.bats
+++ b/test/unit/fetch_json_whitelist.bats
@@ -62,27 +62,33 @@ teardown() {
   assert_file_contains_lines "$V6_OUT" "2600:1900::/32" "2607:f8b0::/32"
 }
 
-@test "fetch_json_whitelist: malformed jq filter warns and skips, does not abort" {
+@test "fetch_json_whitelist: malformed jq filter dies (fail-fast)" {
   WHITELIST_JSON_SOURCES=(
     "file://${FIXTURES_DIR}/whitelist-mullvad.json|.this is not valid jq[("
-    "file://${FIXTURES_DIR}/whitelist-mullvad.json|.wireguard.relays[].ipv4_addr_in"
   )
 
   run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
 
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"jq filter failed"* ]]
-  # Second valid entry should still produce output
-  assert_file_contains_lines "$V4_OUT" "185.213.154.66"
 }
 
-@test "fetch_json_whitelist: invalid entry without pipe is rejected" {
+@test "fetch_json_whitelist: invalid entry without pipe dies" {
   WHITELIST_JSON_SOURCES=("file://${FIXTURES_DIR}/whitelist-mullvad.json")
 
   run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
 
-  [ "$status" -eq 1 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid WHITELIST_JSON_SOURCES entry"* ]]
+}
+
+@test "fetch_json_whitelist: download failure dies (fail-fast)" {
+  WHITELIST_JSON_SOURCES=("file://${BATS_TMPDIR}/does-not-exist-$$.json|.[]")
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Failed to download whitelist source"* ]]
 }
 
 @test "fetch_json_whitelist: filter containing additional pipes is preserved (split on first |)" {

--- a/test/unit/fetch_json_whitelist.bats
+++ b/test/unit/fetch_json_whitelist.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+#
+# Unit tests for fetch_json_whitelist() function
+#
+
+load '../helpers/test_helper'
+
+setup() {
+  command -v jq >/dev/null || skip "jq not installed"
+  load_script_functions
+  mkdir -p "${BATS_TMPDIR}/work"
+
+  # Stub out logging to avoid bleeding into output
+  CRON_MODE=no
+  export V4_OUT="${BATS_TMPDIR}/work/v4.txt"
+  export V6_OUT="${BATS_TMPDIR}/work/v6.txt"
+  : > "$V4_OUT"
+  : > "$V6_OUT"
+}
+
+teardown() {
+  rm -rf "${BATS_TMPDIR}/work"
+}
+
+@test "fetch_json_whitelist: extracts Mullvad IPv4 relay addresses" {
+  WHITELIST_JSON_SOURCES=("file://${FIXTURES_DIR}/whitelist-mullvad.json|.wireguard.relays[].ipv4_addr_in")
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 0 ]
+  assert_file_contains_lines "$V4_OUT" "185.213.154.66" "185.213.154.67" "193.32.127.66"
+  [ ! -s "$V6_OUT" ]
+}
+
+@test "fetch_json_whitelist: routes IPv6 to v6 output" {
+  WHITELIST_JSON_SOURCES=("file://${FIXTURES_DIR}/whitelist-mullvad.json|.wireguard.relays[].ipv6_addr_in")
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 0 ]
+  [ ! -s "$V4_OUT" ]
+  assert_file_contains_lines "$V6_OUT" "2a03:1b20:1:f011::a01f" "2a03:1b20:1:f011::a020"
+}
+
+@test "fetch_json_whitelist: gcloud filter returns CIDRs into v4 output" {
+  WHITELIST_JSON_SOURCES=("file://${FIXTURES_DIR}/whitelist-gcloud.json|.prefixes[].ipv4Prefix // empty")
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 0 ]
+  assert_file_contains_lines "$V4_OUT" "34.0.0.0/15" "35.190.0.0/17"
+  [ ! -s "$V6_OUT" ]
+}
+
+@test "fetch_json_whitelist: gcloud IPv6 filter routes CIDRs to v6 output" {
+  WHITELIST_JSON_SOURCES=("file://${FIXTURES_DIR}/whitelist-gcloud.json|.prefixes[].ipv6Prefix // empty")
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 0 ]
+  [ ! -s "$V4_OUT" ]
+  assert_file_contains_lines "$V6_OUT" "2600:1900::/32" "2607:f8b0::/32"
+}
+
+@test "fetch_json_whitelist: malformed jq filter warns and skips, does not abort" {
+  WHITELIST_JSON_SOURCES=(
+    "file://${FIXTURES_DIR}/whitelist-mullvad.json|.this is not valid jq[("
+    "file://${FIXTURES_DIR}/whitelist-mullvad.json|.wireguard.relays[].ipv4_addr_in"
+  )
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"jq filter failed"* ]]
+  # Second valid entry should still produce output
+  assert_file_contains_lines "$V4_OUT" "185.213.154.66"
+}
+
+@test "fetch_json_whitelist: invalid entry without pipe is rejected" {
+  WHITELIST_JSON_SOURCES=("file://${FIXTURES_DIR}/whitelist-mullvad.json")
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid WHITELIST_JSON_SOURCES entry"* ]]
+}
+
+@test "fetch_json_whitelist: filter containing additional pipes is preserved (split on first |)" {
+  # jq alternation operator '|' inside the filter should survive entry split.
+  # Filter pipes the array stream through select() then extracts the field.
+  WHITELIST_JSON_SOURCES=("file://${FIXTURES_DIR}/whitelist-mullvad.json|.wireguard.relays[] | select(.hostname == \"test-wg-002\") | .ipv4_addr_in")
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 0 ]
+  assert_file_contains_lines "$V4_OUT" "185.213.154.67"
+  assert_file_excludes_lines "$V4_OUT" "185.213.154.66" "193.32.127.66"
+}
+
+@test "fetch_json_whitelist: empty WHITELIST_JSON_SOURCES returns 1 (nothing added)" {
+  WHITELIST_JSON_SOURCES=()
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 1 ]
+  [ ! -s "$V4_OUT" ]
+  [ ! -s "$V6_OUT" ]
+}
+
+@test "fetch_json_whitelist: filter producing empty output returns 1" {
+  WHITELIST_JSON_SOURCES=("file://${FIXTURES_DIR}/whitelist-mullvad.json|.wireguard.relays[] | select(.hostname == \"does-not-exist\") | .ipv4_addr_in")
+
+  run fetch_json_whitelist "$V4_OUT" "$V6_OUT"
+
+  [ "$status" -eq 1 ]
+  [ ! -s "$V4_OUT" ]
+  [ ! -s "$V6_OUT" ]
+}

--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -306,6 +306,58 @@ apply_whitelist() {
   return 0
 }
 
+# Fetch JSON whitelist sources, apply jq filter, and append extracted IPs
+# Arguments:
+#   $1 - output file for IPv4 entries (appended)
+#   $2 - output file for IPv6 entries (appended)
+# Returns: 0 if at least one entry was added, 1 otherwise
+fetch_json_whitelist() {
+  local v4_out="$1" v6_out="$2"
+  local added=0
+  local entry url filter tmp jq_out ip count
+
+  for entry in "${WHITELIST_JSON_SOURCES[@]:-}"; do
+    [[ -z "$entry" ]] && continue
+    [[ "$entry" =~ ^# ]] && continue
+
+    # Split on first '|' so jq filters containing '|' (alt operator) survive
+    url="${entry%%|*}"
+    filter="${entry#*|}"
+
+    if [[ "$url" == "$entry" ]] || [[ -z "$url" ]] || [[ -z "$filter" ]]; then
+      log_warn "Invalid WHITELIST_JSON_SOURCES entry (expected URL|FILTER): $entry"
+      continue
+    fi
+
+    tmp=$(make_temp)
+    if ! download_blacklist "$url" "$tmp"; then
+      continue
+    fi
+
+    jq_out=$(make_temp)
+    if ! jq -r "$filter" "$tmp" > "$jq_out" 2>/dev/null; then
+      log_warn "jq filter failed for $url (filter: $filter)"
+      continue
+    fi
+
+    count=0
+    while IFS= read -r ip || [[ -n "$ip" ]]; do
+      [[ -z "$ip" ]] && continue
+      if [[ "$ip" == *:* ]]; then
+        echo "$ip" >> "$v6_out"
+      else
+        echo "$ip" >> "$v4_out"
+      fi
+      ((count++)) || true
+    done < "$jq_out"
+
+    log_info "  Loaded $count IPs from $url"
+    (( count > 0 )) && added=1
+  done
+
+  return $(( added == 1 ? 0 : 1 ))
+}
+
 #=============================================================================
 # NFTABLES MANAGEMENT FUNCTIONS
 #=============================================================================
@@ -569,6 +621,9 @@ main() {
     fi
   fi
 
+  # Default optional arrays if not declared in config
+  [[ "$(declare -p WHITELIST_JSON_SOURCES 2>/dev/null)" == "declare -a"* ]] || WHITELIST_JSON_SOURCES=()
+
   # Apply defaults for optional settings
   : "${NFT_TABLE_NAME:=blacklist}"
   : "${NFT_SET_NAME_V4:=blacklist4}"
@@ -584,6 +639,10 @@ main() {
 
   # Validate required commands
   local required_cmds=(curl grep sed sort wc iprange)
+  # jq is only required when JSON whitelist sources are configured
+  if (( ${#WHITELIST_JSON_SOURCES[@]:-0} > 0 )); then
+    required_cmds+=(jq)
+  fi
   for cmd in "${required_cmds[@]}"; do
     if ! exists "$cmd"; then
       die "Required command not found: $cmd (install with: apt install $cmd)"
@@ -731,6 +790,14 @@ main() {
       fi
     done
     has_whitelist=yes
+  fi
+
+  # Fetch JSON whitelist sources (jq-extracted)
+  if (( ${#WHITELIST_JSON_SOURCES[@]:-0} > 0 )); then
+    log_info "Fetching JSON whitelist sources..."
+    if fetch_json_whitelist "$whitelist_v4" "$whitelist_v6"; then
+      has_whitelist=yes
+    fi
   fi
 
   # Auto-detect server IPs if enabled

--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -306,7 +306,10 @@ apply_whitelist() {
   return 0
 }
 
-# Fetch JSON whitelist sources, apply jq filter, and append extracted IPs
+# Fetch JSON whitelist sources, apply jq filter, and append extracted IPs.
+# Fail-fast on download or jq errors: under-whitelisting is the inverse risk
+# this feature exists to prevent (silently letting your VPN endpoints get
+# blacklisted because the relay API hiccupped is the wrong default).
 # Arguments:
 #   $1 - output file for IPv4 entries (appended)
 #   $2 - output file for IPv6 entries (appended)
@@ -318,26 +321,23 @@ fetch_json_whitelist() {
 
   for entry in "${WHITELIST_JSON_SOURCES[@]:-}"; do
     [[ -z "$entry" ]] && continue
-    [[ "$entry" =~ ^# ]] && continue
 
     # Split on first '|' so jq filters containing '|' (alt operator) survive
     url="${entry%%|*}"
     filter="${entry#*|}"
 
     if [[ "$url" == "$entry" ]] || [[ -z "$url" ]] || [[ -z "$filter" ]]; then
-      log_warn "Invalid WHITELIST_JSON_SOURCES entry (expected URL|FILTER): $entry"
-      continue
+      die "Invalid WHITELIST_JSON_SOURCES entry (expected URL|FILTER): $entry"
     fi
 
     tmp=$(make_temp)
-    if ! download_blacklist "$url" "$tmp"; then
-      continue
+    if ! download_blacklist "$url" "$tmp" || [[ ! -s "$tmp" ]]; then
+      die "Failed to download whitelist source: $url"
     fi
 
     jq_out=$(make_temp)
     if ! jq -r "$filter" "$tmp" > "$jq_out" 2>/dev/null; then
-      log_warn "jq filter failed for $url (filter: $filter)"
-      continue
+      die "jq filter failed for $url (filter: $filter)"
     fi
 
     count=0
@@ -351,8 +351,12 @@ fetch_json_whitelist() {
       ((count++)) || true
     done < "$jq_out"
 
-    log_info "  Loaded $count IPs from $url"
-    (( count > 0 )) && added=1
+    if (( count > 0 )); then
+      log_info "  Loaded $count IPs from $url"
+      added=1
+    else
+      log_warn "  Filter produced 0 IPs from $url (filter: $filter)"
+    fi
   done
 
   return $(( added == 1 ? 0 : 1 ))

--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -640,7 +640,7 @@ main() {
   # Validate required commands
   local required_cmds=(curl grep sed sort wc iprange)
   # jq is only required when JSON whitelist sources are configured
-  if (( ${#WHITELIST_JSON_SOURCES[@]:-0} > 0 )); then
+  if (( ${#WHITELIST_JSON_SOURCES[@]} > 0 )); then
     required_cmds+=(jq)
   fi
   for cmd in "${required_cmds[@]}"; do
@@ -793,7 +793,7 @@ main() {
   fi
 
   # Fetch JSON whitelist sources (jq-extracted)
-  if (( ${#WHITELIST_JSON_SOURCES[@]:-0} > 0 )); then
+  if (( ${#WHITELIST_JSON_SOURCES[@]} > 0 )); then
     log_info "Fetching JSON whitelist sources..."
     if fetch_json_whitelist "$whitelist_v4" "$whitelist_v6"; then
       has_whitelist=yes


### PR DESCRIPTION
## Summary

Resolves the feature request to support JSON endpoints as whitelist sources, with `jq` field extraction (similar to OPNsense's pattern).

- New `WHITELIST_JSON_SOURCES` config array; each entry is `"URL|JQ_FILTER"` (split on the first `|`, so jq operators like `|` and `//` are preserved).
- Supports `https://`, `http://`, and `file:///` — same as `BLACKLISTS`.
- IPv4 vs IPv6 routing is automatic (entries containing `:` go to the IPv6 whitelist).
- `jq` is **conditionally required** — only enforced when `WHITELIST_JSON_SOURCES` has entries; empty configs work without `jq` installed. Fail-fast if jq is missing while sources are configured (silent skip would be a security hole — user would think provider IPs were protected when they weren't).

## Examples

```bash
WHITELIST_JSON_SOURCES=(
    "https://api.mullvad.net/app/v1/relays|.wireguard.relays[].ipv4_addr_in"
    "file:///etc/nftables-blacklist/my-whitelist.json|.[]"
)
```

## Test plan

- [x] Unit tests: 9/9 pass — `test/unit/fetch_json_whitelist.bats` (extraction, v4/v6 routing, `// empty`, malformed-jq tolerance, missing-pipe rejection, first-`|` split semantics, empty cases).
- [x] Integration matrix: 8 rows — `test/integration/whitelist_modes.bats` covers literal × json × jq present/absent. Uses a hermetic PATH sandbox to simulate "jq not installed". Skips on macOS where `iprange`/`nft` aren't available — runs in CI.
- [x] `bash -n` and `shellcheck` clean.
- [x] No regressions in pre-existing unit tests.