### PR TITLE
Add file:// support to WHITELIST for external whitelist files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Blacklist update complete
 - [Configuration Options](#configuration-options)
 - [Customizing Blacklists](#customizing-blacklists)
 - [Whitelist (Prevent Self-Blocking)](#whitelist-prevent-self-blocking)
+  - [Manual Whitelist](#manual-whitelist)
+  - [External whitelist files](#external-whitelist-files)
+  - [Auto-Detect Server IPs](#auto-detect-server-ips)
 - [Dry Run Mode](#dry-run-mode)
 - [Cron Mode](#cron-mode)
 - [Troubleshooting](#troubleshooting)
@@ -255,6 +258,39 @@ WHITELIST=(
 For IPv4, whitelisting a range like `10.0.0.0/8` will correctly exclude all IPs in that range, even if the blacklist contains individual IPs like `10.1.2.3`.
 
 **Note:** IPv6 whitelist only matches exact addresses (CIDR ranges not supported for IPv6 whitelist).
+
+### External whitelist files
+
+`WHITELIST` entries may also be `file://` URLs pointing at a flat text file (one IP/CIDR per line, `#` starts a comment, blank lines are ignored). This lets you keep large or dynamically-generated whitelists outside the bash config:
+
+```bash
+WHITELIST=(
+    "203.0.113.10"
+    "file:///etc/nftables-blacklist/extra.list"
+)
+```
+
+If the file is missing or unreadable, the script aborts before applying any rules — silently dropping a configured whitelist would let IPs you intended to protect get blacklisted, which is exactly what this feature exists to prevent.
+
+**Recipe: dynamic whitelist from a JSON API**
+
+To whitelist e.g. all Mullvad WireGuard relays (or any other JSON endpoint), schedule a small cron job that writes a flat list using `jq`, then point a `WHITELIST` entry at it:
+
+```bash
+# /etc/cron.daily/refresh-mullvad-whitelist
+#!/bin/sh
+curl -fsSL https://api.mullvad.net/app/v1/relays \
+  | jq -r '.wireguard.relays[].ipv4_addr_in' \
+  > /etc/nftables-blacklist/mullvad.list
+```
+
+```bash
+WHITELIST=(
+    "file:///etc/nftables-blacklist/mullvad.list"
+)
+```
+
+Run the cron before `update-blacklist.sh` (or schedule the cron earlier in the day). `jq` is the user's tool, not a dependency of this project — use whatever preprocessing you like (`jq`, `awk`, `python`, hand-edited) as long as the result is one IP/CIDR per line.
 
 ### Auto-Detect Server IPs
 

--- a/nftables-blacklist.conf
+++ b/nftables-blacklist.conf
@@ -63,12 +63,17 @@ BLACKLISTS=(
 # Auto-detect and whitelist this server's IPs (default: no, recommended: yes)
 # AUTO_WHITELIST=no
 
-# Manual whitelist entries (IPv6 uses exact matching only)
+# Manual whitelist entries (IPv6 uses exact matching only).
+# Each entry is either a literal IP/CIDR, or a "file://" URL pointing at a
+# flat list (one IP/CIDR per line, '#' for comments). See README for a
+# cron+jq recipe that populates such a file from JSON endpoints (e.g.
+# Mullvad relays, cloud-provider IP ranges).
 WHITELIST=(
   # Add your server's IP and network here to prevent self-blocking
-  # "203.0.113.10"       # Single IP
-  # "203.0.113.0/24"     # CIDR range
-  # "2001:db8::1"        # IPv6
+  # "203.0.113.10"                                # Single IP
+  # "203.0.113.0/24"                              # CIDR range
+  # "2001:db8::1"                                 # IPv6
+  # "file:///etc/nftables-blacklist/extra.list"   # External list
 )
 
 #=== OPTIONAL OVERRIDES ===#

--- a/test/integration/whitelist_file.bats
+++ b/test/integration/whitelist_file.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+#
+# Integration tests for file:// support in WHITELIST.
+#
+
+load '../helpers/test_helper'
+
+setup() {
+  command -v iprange >/dev/null || skip "iprange not installed"
+
+  export TEST_OUTPUT_DIR="${BATS_TMPDIR}/nftables-blacklist"
+  mkdir -p "${TEST_OUTPUT_DIR}"
+  chmod 777 "${TEST_OUTPUT_DIR}"
+
+  export WL_INCLUDE="${BATS_TMPDIR}/extra-whitelist.list"
+  export V4_LIST="${TEST_OUTPUT_DIR}/ip-blacklist.list.v4"
+  export V6_LIST="${TEST_OUTPUT_DIR}/ip-blacklist.list.v6"
+
+  # Synthetic blacklist with the IPs we want to test whitelisting against
+  export TEST_BL="${BATS_TMPDIR}/synthetic-blacklist.txt"
+  cat > "${TEST_BL}" <<'EOF'
+1.2.3.4
+185.213.154.66
+2001:4860:4860::8888
+2606:4700:4700::1111
+EOF
+}
+
+teardown() {
+  rm -rf "${BATS_TMPDIR}/nftables-blacklist"
+  rm -f "${BATS_TMPDIR}"/test-config-*.conf "${WL_INCLUDE}" "${TEST_BL}"
+}
+
+write_config() {
+  local path="$1" wl="$2"
+  cat > "$path" <<EOF
+BLACKLISTS=( "file://${TEST_BL}" )
+
+NFT_BLACKLIST_SCRIPT="${TEST_OUTPUT_DIR}/blacklist.nft"
+IP_BLACKLIST="${TEST_OUTPUT_DIR}/ip-blacklist.list"
+
+NFT_TABLE_NAME="test_blacklist"
+NFT_SET_NAME_V4="test_blacklist4"
+NFT_SET_NAME_V6="test_blacklist6"
+NFT_CHAIN_NAME="test_input"
+NFT_CHAIN_PRIORITY=-200
+
+ENABLE_IPV4=yes
+ENABLE_IPV6=yes
+AUTO_WHITELIST=no
+CHUNK_SIZE=100
+
+WHITELIST=( ${wl} )
+EOF
+}
+
+@test "file:// WHITELIST: filters IPv4 from blacklist" {
+  cat > "${WL_INCLUDE}" <<'EOF'
+185.213.154.66
+EOF
+  local cfg="${BATS_TMPDIR}/test-config-1.conf"
+  write_config "$cfg" '"file://'"${WL_INCLUDE}"'"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^185\.213\.154\.66$" "$V4_LIST"
+  grep -q "^1\.2\.3\.4$" "$V4_LIST"
+}
+
+@test "file:// WHITELIST: filters exact-match IPv6" {
+  cat > "${WL_INCLUDE}" <<'EOF'
+2606:4700:4700::1111
+EOF
+  local cfg="${BATS_TMPDIR}/test-config-2.conf"
+  write_config "$cfg" '"file://'"${WL_INCLUDE}"'"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "2606:4700:4700::1111" "$V6_LIST"
+  grep -q "2001:4860:4860::8888" "$V6_LIST"
+}
+
+@test "file:// WHITELIST: comments, blank lines, whitespace are stripped" {
+  cat > "${WL_INCLUDE}" <<'EOF'
+# Mullvad relays
+185.213.154.66
+   2606:4700:4700::1111   # whitespace + inline comment
+
+# blank lines above too
+EOF
+  local cfg="${BATS_TMPDIR}/test-config-3.conf"
+  write_config "$cfg" '"file://'"${WL_INCLUDE}"'"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^185\.213\.154\.66$" "$V4_LIST"
+  ! grep -q "2606:4700:4700::1111" "$V6_LIST"
+}
+
+@test "file:// WHITELIST: missing file aborts the run" {
+  local cfg="${BATS_TMPDIR}/test-config-4.conf"
+  write_config "$cfg" '"file:///nonexistent/path-'"$$"'.list"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"WHITELIST file not readable"* ]]
+}
+
+@test "file:// WHITELIST: mixed literal + file entries both apply" {
+  cat > "${WL_INCLUDE}" <<'EOF'
+185.213.154.66
+EOF
+  local cfg="${BATS_TMPDIR}/test-config-5.conf"
+  write_config "$cfg" '"2606:4700:4700::1111" "file://'"${WL_INCLUDE}"'"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -eq 0 ]
+  # From file
+  ! grep -q "^185\.213\.154\.66$" "$V4_LIST"
+  # From literal
+  ! grep -q "2606:4700:4700::1111" "$V6_LIST"
+  # Survives
+  grep -q "^1\.2\.3\.4$" "$V4_LIST"
+  grep -q "2001:4860:4860::8888" "$V6_LIST"
+}

--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -719,12 +719,32 @@ main() {
   whitelist_v6=$(make_temp)
   local has_whitelist=no
 
-  # Collect manual whitelist entries
+  # Collect manual whitelist entries.
+  # Each entry is either a literal IP/CIDR or a "file://" URL pointing at a
+  # flat list (one IP/CIDR per line, '#' starts a comment). Files let users
+  # plug in externally-generated whitelists (e.g. a cron-driven jq pipeline
+  # against Mullvad/cloud-provider APIs) without coupling that tooling to
+  # this script.
   if [[ -n "${WHITELIST[*]:-}" ]]; then
     for entry in "${WHITELIST[@]}"; do
       [[ -z "$entry" ]] && continue
-      # Determine if IPv4 or IPv6 based on presence of colon
-      if [[ "$entry" == *:* ]]; then
+      if [[ "$entry" == file://* ]]; then
+        local wl_path="${entry#file://}"
+        if [[ ! -r "$wl_path" ]]; then
+          die "WHITELIST file not readable: $wl_path"
+        fi
+        local line
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          line="${line%%#*}"
+          line="${line//[[:space:]]/}"
+          [[ -z "$line" ]] && continue
+          if [[ "$line" == *:* ]]; then
+            echo "$line" >> "$whitelist_v6"
+          else
+            echo "$line" >> "$whitelist_v4"
+          fi
+        done < "$wl_path"
+      elif [[ "$entry" == *:* ]]; then
         echo "$entry" >> "$whitelist_v6"
       else
         echo "$entry" >> "$whitelist_v4"


### PR DESCRIPTION
## Summary

Smaller-footprint alternative to #115 that satisfies the same GitHub feature request (whitelist Mullvad / cloud-provider IPs from JSON endpoints) **without** introducing `jq` as a dependency.

Each `WHITELIST` entry can now be a `file://` URL pointing at a flat list (one IP/CIDR per line, `#` for comments). Users run their own preprocessing — a cron+jq one-liner is documented in the README — and this script just reads the result. `jq` becomes the user's tool, not the project's.

### vs #115

|  | PR #115 | This PR |
|---|---|---|
| New deps | `jq` (gated) | none |
| New helper | `fetch_json_whitelist` (~55 LoC) | reuses existing WHITELIST loop |
| Net change to `update-blacklist.sh` | +70 | +25 |
| New test code | ~330 LoC (unit + 8-row matrix) | ~120 LoC (5 integration tests) |
| Field precision | jq filter | none — file is the user's concern |
| Failure mode | fail-fast on download/jq error | fail-fast on unreadable file |

Pick whichever you prefer. **#115 stays open and untouched** until you decide.

## Test plan

- [x] `bash -n` and `shellcheck` clean
- [x] New integration tests cover: IPv4 filtering via file, IPv6 exact-match filtering via file, comment/whitespace/blank-line stripping, missing-file aborts, mixed literal+file entries
- [x] Existing tests untouched