### PR TITLE
Update README with dynamic whitelist cron job instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,15 +274,24 @@ If the file is missing or unreadable, the script aborts before applying any rule
 
 **Recipe: dynamic whitelist from a JSON API**
 
-To whitelist e.g. all Mullvad WireGuard relays (or any other JSON endpoint), schedule a small cron job that writes a flat list using `jq`, then point a `WHITELIST` entry at it:
+To whitelist e.g. all Mullvad WireGuard relays (or any other JSON endpoint), schedule a small cron job that writes a flat list using `jq`, then point a `WHITELIST` entry at it.
+
+Create a new daily cronjob file `/etc/cron.daily/refresh-mullvad-whitelist` with the content (Mullvad is just an example):
 
 ```bash
-# /etc/cron.daily/refresh-mullvad-whitelist
 #!/bin/sh
 curl -fsSL https://api.mullvad.net/app/v1/relays \
   | jq -r '.wireguard.relays[].ipv4_addr_in' \
   > /etc/nftables-blacklist/mullvad.list
 ```
+
+Give the new cronjob file execute permissions:
+
+```bash
+sudo chmod +x /etc/cron.daily/refresh-mullvad-whitelist
+```
+
+Finally, update your `/etc/nftables-blacklist/nftables-blacklist.conf` file:
 
 ```bash
 WHITELIST=(


### PR DESCRIPTION
- Better instructions for creating a cron job to refresh the Mullvad WireGuard whitelist.
- Explicitly add execute rights etc using `chmod +x` ! Many people might forget this!
- Make it more clear what to change/what file, what the content is.

---

**ps. Small problem ..**

It is kinda strange that my whitelist didn't grew..?

I download the latest version first (so I have your latest updates):

```sh
sudo curl -fsSL -o /usr/local/sbin/update-blacklist.sh \
  https://raw.githubusercontent.com/trick77/nftables-blacklist/master/update-blacklist.sh
sudo chmod +x /usr/local/sbin/update-blacklist.sh
```

Setup my cronjob and triggered it. I have now my mullvad.list, right?:

```sh
file /etc/nftables-blacklist/mullvad.list
/etc/nftables-blacklist/mullvad.list: ASCII text
```

With content:

```sh
-rw-r--r--   1 root root 7.8K May  3 15:29 mullvad.list
```

And I added this file to the whitelist, so far so good:

```conf
WHITELIST=(
  # Add your server's IP and network here to prevent self-blocking
  # My public external IP
  "x.x.x.xx"
  # localhost ipv4
  "127.0.0.1/8"
  # LAN
  "192.168.1.0/24"
  # Docker
  "172.17.0.0/16"
  "10.254.0.0/16"

  # Tor
  "https://check.torproject.org/torbulkexitlist"

  # Google
  "https://www.gstatic.com/ipranges/cloud.json"
  "https://www.gstatic.com/ipranges/goog.txt"

  # Mullvad
  "file:///etc/nftables-blacklist/mullvad.list"
```

Then I manually triggered an update, with the result:

```sh
info: Downloading blacklists...
info: Downloaded 7 of 7 blacklists
info: Processing IPv4 addresses...
info: CIDR optimization: 227690 → 202468 entries
info: Applying IPv4 whitelist...
info: Whitelist applied: 202468 → 202468 entries (SAME?)
info: Generating nftables script...
info: Applying nftables rules...
info: Blacklist update complete
info: IPv4: 202468  IPv6: 0  Total: 202468
```

Whitelist is still the same amount of entries? That is kinda weird.

Yes, I checked .. the last time it trigger was 13 hours ago... So my manual trigger just now, should have increase the whitelist entries.. or so I thought.. 

```sh
○ nftables-blacklist-update.service - Update nftables IP blacklist
     Loaded: loaded (/etc/systemd/system/nftables-blacklist-update.service; static)
     Active: inactive (dead) since Sun 2026-05-03 02:11:17 CEST; 13h ago
TriggeredBy: ● nftables-blacklist-update.timer
    Process: 4144649 ExecStart=/usr/local/sbin/update-blacklist.sh --cron /etc/nftables-blacklist/nftables-blacklist.conf (code=exited, status=0/SUCCESS)
   Main PID: 4144649 (code=exited, status=0/SUCCESS)
        CPU: 8.304s

May 03 02:11:12 ubuntu-server update-blacklist.sh[4144649]: info: CIDR optimization: 229654 → 204769 entries
May 03 02:11:12 ubuntu-server update-blacklist.sh[4144649]: info: Applying IPv4 whitelist...
May 03 02:11:12 ubuntu-server update-blacklist.sh[4144649]: info: Whitelist applied: 204769 → 204769 entries
May 03 02:11:12 ubuntu-server update-blacklist.sh[4144649]: info: Generating nftables script...
May 03 02:11:12 ubuntu-server update-blacklist.sh[4144649]: info: Applying nftables rules...
May 03 02:11:17 ubuntu-server update-blacklist.sh[4144649]: info: Blacklist update complete
May 03 02:11:17 ubuntu-server update-blacklist.sh[4144649]: info: IPv4: 204769  IPv6: 0  Total: 204769
```


Are you SURE that `file://` is working??