### PR TITLE
Reject unknown URL schemes in WHITELIST instead of silently ignoring

### DIFF
--- a/nftables-blacklist.conf
+++ b/nftables-blacklist.conf
@@ -65,9 +65,11 @@ BLACKLISTS=(
 
 # Manual whitelist entries (IPv6 uses exact matching only).
 # Each entry is either a literal IP/CIDR, or a "file://" URL pointing at a
-# flat list (one IP/CIDR per line, '#' for comments). See README for a
-# cron+jq recipe that populates such a file from JSON endpoints (e.g.
-# Mullvad relays, cloud-provider IP ranges).
+# flat list (one IP/CIDR per line, '#' for comments). HTTPS/HTTP URLs are
+# NOT supported here (unlike BLACKLISTS) - fetch external lists out-of-band
+# into a local file and reference it via file://. See README for a recipe
+# that populates such a file from JSON endpoints (e.g. Mullvad relays,
+# cloud-provider IP ranges).
 WHITELIST=(
   # Add your server's IP and network here to prevent self-blocking
   # "203.0.113.10"                                # Single IP

--- a/test/integration/whitelist_file.bats
+++ b/test/integration/whitelist_file.bats
@@ -110,6 +110,26 @@ EOF
   [[ "$output" == *"WHITELIST file not readable"* ]]
 }
 
+@test "WHITELIST: rejects https:// URL with a clear error" {
+  local cfg="${BATS_TMPDIR}/test-config-https.conf"
+  write_config "$cfg" '"https://example.com/list.txt"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"WHITELIST does not support URL scheme"* ]]
+}
+
+@test "WHITELIST: rejects http:// URL with a clear error" {
+  local cfg="${BATS_TMPDIR}/test-config-http.conf"
+  write_config "$cfg" '"http://example.com/list.txt"'
+
+  run "${SCRIPT_PATH}" --dry-run "$cfg"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"WHITELIST does not support URL scheme"* ]]
+}
+
 @test "file:// WHITELIST: mixed literal + file entries both apply" {
   cat > "${WL_INCLUDE}" <<'EOF'
 185.213.154.66

--- a/update-blacklist.sh
+++ b/update-blacklist.sh
@@ -744,6 +744,13 @@ main() {
             echo "$line" >> "$whitelist_v4"
           fi
         done < "$wl_path"
+      elif [[ "$entry" =~ ^[a-zA-Z][a-zA-Z0-9+.-]*:// ]]; then
+        # Reject unknown URL schemes (https://, http://, ftp://, ...). The
+        # WHITELIST array only accepts literal IP/CIDR entries and file://
+        # paths. Silently writing an HTTPS URL into the whitelist would be
+        # ignored by iprange and let the IPs the operator wanted to protect
+        # get blacklisted - the same failure mode the file:// die guards.
+        die "WHITELIST does not support URL scheme in entry: $entry (only literal IP/CIDR or file:// is supported; fetch external lists out-of-band)"
       elif [[ "$entry" == *:* ]]; then
         echo "$entry" >> "$whitelist_v6"
       else


### PR DESCRIPTION
## Summary
- Putting an `https://` (or any non-`file://`) URL in `WHITELIST` was silently misclassified — the colon triggered the v6 classifier, the URL string went into the IPv6 whitelist temp file, and `iprange`/`grep` ignored it as a non-IP line. The operator saw no error but the IPs they meant to protect were not actually whitelisted.
- This is the exact failure mode the `file://` missing-file `die` was added to prevent (see commit 26af968). Surfaced by @melroy89 in #117.
- Detect any URL scheme prefix (`<scheme>://`) that isn't `file://` and abort with a clear message pointing users at the `file://` recipe.
- Updates the conf comment to spell out HTTPS is **not** supported here, since `BLACKLISTS` does support it and users assume parity.
- Adds two bats tests (`https://` and `http://`) — total tests in `whitelist_file.bats` go from 5 to 7.

## Test plan
- [x] `bash -n update-blacklist.sh` — syntax clean
- [x] `bats --count test/integration/whitelist_file.bats` returns 7
- [ ] CI runs full bats suite with `iprange` available