### PR TITLE
Refresh example blacklist feeds and replace stale sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ BLACKLISTS=(
     "file:///etc/nftables-blacklist/custom.list"
 
     # Public blacklists
-    "https://www.spamhaus.org/drop/drop.lasso"
+    "https://www.spamhaus.org/drop/drop_v4.json"
     "https://lists.blocklist.de/lists/all.txt"
 
     # Ban an entire country (use country code like 'cn', 'ru', etc.)

--- a/nftables-blacklist.conf
+++ b/nftables-blacklist.conf
@@ -29,10 +29,10 @@ BLACKLISTS=(
   "http://danger.rulez.sk/projects/bruteforceblocker/blist.php"
 
   # Spamhaus DROP List (IPv4) - Don't Route Or Peer
-  "https://www.spamhaus.org/drop/drop.txt"
+  "https://www.spamhaus.org/drop/drop_v4.json"
 
   # Spamhaus DROP List (IPv6)
-  "https://www.spamhaus.org/drop/dropv6.txt"
+  "https://www.spamhaus.org/drop/drop_v6.json"
 
   # C.I. Army Malicious IP List
   "https://cinsscore.com/list/ci-badguys.txt"
@@ -43,11 +43,15 @@ BLACKLISTS=(
   # GreenSnow Blocklist
   "https://blocklist.greensnow.co/greensnow.txt"
 
-  # FireHOL Level 1 (aggregated)
-  "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level1.netset"
+  # FireHOL Level 1 (aggregated: dshield, feodo, fullbogons, spamhaus_drop)
+  # Use iplists.firehol.org direct - GitHub sync is broken, see firehol/blocklist-ipsets#366
+  "https://iplists.firehol.org/files/firehol_level1.netset"
 
   # StopForumSpam (7 days)
-  "https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/stopforumspam_7d.ipset"
+  "https://iplists.firehol.org/files/stopforumspam_7d.ipset"
+
+  # Emerging Threats - Compromised hosts
+  "https://rules.emergingthreats.net/blockrules/compromised-ips.txt"
 
   # Country/ASN blocks (uncomment and edit as needed)
   # Use https://lens.ipverse.net to look up ASN and network info


### PR DESCRIPTION
## Summary

Audit of the example blacklists in `nftables-blacklist.conf` and `README.md` (run on 2026-05-09) found two stale sources and a deprecated URL format. This PR refreshes them and adds one new feed.

### Changes

- **Spamhaus DROP** — switched the example URLs from legacy `drop.txt` / `dropv6.txt` / `drop.lasso` to the current `drop_v4.json` / `drop_v6.json`. The `.txt` feeds still work but Spamhaus treats JSON as the canonical format (`drop.lasso` 301-redirects to `drop.txt`).
- **FireHOL Level 1 + stopforumspam_7d** — moved off the `raw.githubusercontent.com/firehol/blocklist-ipsets` mirror. That mirror has been frozen at 2026-03-30 for over five weeks even though the embedded metadata claims a 1-minute update cadence (see firehol/blocklist-ipsets#366). The canonical `iplists.firehol.org/files/...` distribution is still updating daily.
- **Emerging Threats compromised-ips** — added as a new source. Long-running, free FOSS feed maintained by Proofpoint; complements the existing brute-force/spammer focus with malware-compromised hosts.

The script's `grep -oE`-based IP extraction (`update-blacklist.sh:131,144`) handles JSON / netset / ipset / plain-text formats transparently, so no code changes are needed.

### Feeds kept (verified live and fresh on 2026-05-09)

- Project Honey Pot RSS
- BruteForceBlocker
- CINS Army
- blocklist.de
- GreenSnow

## Test plan

- [x] `bats test/unit/extract_ipv4.bats test/unit/extract_ipv6.bats` — all 23 extractor tests pass
- [x] `bash -n nftables-blacklist.conf` — config syntax OK
- [x] All nine configured feed URLs return HTTP 200 with `Last-Modified` within the last ~2 days (Project Honey Pot RSS body's `lastBuildDate` confirms freshness for the one that omits the header)
- [ ] Run `update-blacklist.sh` end-to-end against the new conf on a real host and confirm non-empty IPv4 + IPv6 sets