### PR TITLE
Note that the BLACKLISTS entries are examples, not endorsements

### DIFF
--- a/nftables-blacklist.conf
+++ b/nftables-blacklist.conf
@@ -17,6 +17,12 @@ FORCE=yes      # Auto-create nftables table/sets if missing
 #=== BLACKLISTS ===#
 # URLs to download. Supports: https://, http://, file:///
 # Both IPv4 and IPv6 addresses are automatically extracted
+#
+# The feeds below are examples to get you started, not endorsements.
+# Each list has its own update cadence, scope, false-positive rate,
+# and license. Review what suits your environment, and add or remove
+# entries as appropriate. The maintainers of this project are not
+# affiliated with any of these feed providers.
 
 BLACKLISTS=(
   # Local custom list (uncomment to use)

--- a/nftables-blacklist.conf
+++ b/nftables-blacklist.conf
@@ -21,8 +21,7 @@ FORCE=yes      # Auto-create nftables table/sets if missing
 # The feeds below are examples to get you started, not endorsements.
 # Each list has its own update cadence, scope, false-positive rate,
 # and license. Review what suits your environment, and add or remove
-# entries as appropriate. The maintainers of this project are not
-# affiliated with any of these feed providers.
+# entries as appropriate.
 
 BLACKLISTS=(
   # Local custom list (uncomment to use)


### PR DESCRIPTION
## Summary

Adds a short comment block under the `#=== BLACKLISTS ===#` header in `nftables-blacklist.conf` clarifying that the bundled feed URLs are starter examples, not endorsements:

> The feeds below are examples to get you started, not endorsements.
> Each list has its own update cadence, scope, false-positive rate,
> and license. Review what suits your environment, and add or remove
> entries as appropriate. The maintainers of this project are not
> affiliated with any of these feed providers.

Sets expectations for users who pick up the default config — particularly relevant given that some feeds (e.g. Binary Defense, which we considered adding earlier) carry license restrictions, and that the firehol GitHub mirror has been observed going stale for weeks at a time.

## Test plan

- [x] No code changes; only a comment block. `bash -n nftables-blacklist.conf` syntax OK.