### PR TITLE
Relabel file:// whitelist example as 'Local list file'

### DIFF
--- a/nftables-blacklist.conf
+++ b/nftables-blacklist.conf
@@ -75,7 +75,7 @@ WHITELIST=(
   # "203.0.113.10"                                # Single IP
   # "203.0.113.0/24"                              # CIDR range
   # "2001:db8::1"                                 # IPv6
-  # "file:///etc/nftables-blacklist/extra.list"   # External list
+  # "file:///etc/nftables-blacklist/extra.list"   # Local list file
 )
 
 #=== OPTIONAL OVERRIDES ===#


### PR DESCRIPTION
## Summary

The inline comment on the example `file://` whitelist entry called it an "External list", which contradicts the rest of the WHITELIST documentation. The header above the array explicitly tells users to fetch external sources out-of-band **into a local file** and reference it with `file://`. So the file *is* local — only its source data is external. Relabel to "Local list file".

## Test plan

- [x] One-word comment change; no behavioral impact.