### PR TITLE
feat(ci): auto-merge Dependabot patch and minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs once required status checks pass. Gated to patch
+# and minor bumps; major bumps are left for manual review. For grouped updates
+# (see dependabot.yaml) fetch-metadata reports the highest bump in the batch,
+# so a group containing any major update is excluded.
+#
+# Requires branch protection on the default branch with the repo's PR status
+# checks required for `gh pr merge --auto` to have something to wait on.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch and minor updates
+        if: contains(fromJSON('["version-update:semver-patch", "version-update:semver-minor"]'), steps.meta.outputs.update-type)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow enabling auto-merge on Dependabot PRs, gated to patch and minor bumps (major excluded). Requires branch protection with the repo's PR status checks (configured alongside this).