### PR TITLE
Add Dependabot config for weekly GitHub Actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "07:00"
+      timezone: "Europe/Zurich"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
Adds `.github/dependabot.yaml` so Dependabot checks GitHub Actions weekly (Sunday 07:00 Europe/Zurich).

Completes the auto-merge feature from 6ca3f0e (`dependabot-auto-merge.yaml`), which until now had no Dependabot config to generate PRs against.